### PR TITLE
Update 05_composition.go

### DIFF
--- a/Chapter02/02_open_closed_principle/05_composition.go
+++ b/Chapter02/02_open_closed_principle/05_composition.go
@@ -37,7 +37,7 @@ type LoadAll struct {
 	rowConverter
 }
 
-func (loader *LoadPerson) All() ([]Person, error) {
+func (loader *LoadAll) All() ([]Person, error) {
 	rows := loader.loadAllFromDB()
 	defer rows.Close()
 
@@ -55,7 +55,7 @@ func (loader *LoadPerson) All() ([]Person, error) {
 	return output, nil
 }
 
-func (loader *LoadPerson) loadAllFromDB() *sql.Rows {
+func (loader *LoadAll) loadAllFromDB() *sql.Rows {
 	// TODO: implement
 	return nil
 }


### PR DESCRIPTION
본 코드는 golang에서 컴포지션을 통한 추상화 클래스를 사용할 수 있음을 보여주는 예제로써 공통 코드를 rowConverter로 추상화한 후, 각 사용처인 LoadPerson, LoadAll 구조체에 주입한다. 그리고 각 구조체는 나름의 쓰임에 맞게 자신의 내부 메서드를 추가할 수 있음을 보인다. 하지만 본 코드에서는 기능 확장하는 대상의 구조체를 잘못 명시했기에 수정을 요청한다.